### PR TITLE
Use std OnceCell and LazyLock instead of lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ fancy-regex = "0.10.0"
 float-cmp = "0.9.0"
 fn_macros = { version = "0.1.0", path = "fn_macros" }
 hostname = "0.3.1"
-lazy_static = "1.4.0"
 memoffset = "0.8.0"
 num_enum = "0.5.11"
 paste = "1.0.12"

--- a/build.rs
+++ b/build.rs
@@ -228,17 +228,16 @@ pub(super) fn init_symbols(map: &mut super::SymbolMap) {{
     writeln!(
         f,
         "
-lazy_static::lazy_static! {{
-    pub(crate) static ref INTERNED_SYMBOLS: Mutex<ObjectMap> = Mutex::new({{
-        let size: usize = {symbol_len};
-        let mut map = SymbolMap::with_capacity(size);
-        sym::init_symbols(&mut map);
-        ObjectMap {{
-            map,
-            block: Block::new_global(),
-        }}
-    }});
-}}
+use std::sync::LazyLock;
+pub(crate) static INTERNED_SYMBOLS: LazyLock<Mutex<ObjectMap>> = LazyLock::new(|| Mutex::new({{
+    let size: usize = {symbol_len};
+    let mut map = SymbolMap::with_capacity(size);
+    sym::init_symbols(&mut map);
+    ObjectMap {{
+        map,
+        block: Block::new_global(),
+    }}
+}}));
 "
     )
     .unwrap();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -9,13 +9,18 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use fn_macros::defun;
-use lazy_static::lazy_static;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 
 // static hashmap containing all the buffers
-lazy_static! {
-    static ref BUFFERS: Mutex<HashMap<String, &'static LispBuffer>> =
-        Mutex::new(HashMap::default());
+static BUFFERS: OnceLock<Mutex<HashMap<String, &'static LispBuffer>>> = OnceLock::new();
+
+/// Helper function to avoid calling `get_or_init` on each of the calls to `lock()` on the Mutex.
+///
+/// TODO: Once [`LazyLock`] is stabilized, this can be changed to initializing on the LazyLock::new() method.
+/// Stabilization tracker: https://github.com/rust-lang/rust/issues/109736
+fn buffers() -> &'static Mutex<HashMap<String, &'static LispBuffer>> {
+    BUFFERS.get_or_init(|| Mutex::new(HashMap::default()))
 }
 
 #[defun]
@@ -34,7 +39,7 @@ fn resolve_buffer<'ob>(buffer_or_name: GcObj, cx: &'ob Context) -> Result<&'ob L
         Object::Buffer(b) => Ok(b),
         Object::String(s) => {
             let name: &str = s.try_into()?;
-            let buffer_list = BUFFERS.lock().unwrap();
+            let buffer_list = buffers().lock().unwrap();
             let Some(buffer) = buffer_list.get(name) else {
                 bail!("No buffer named {}", name);
             };
@@ -72,7 +77,7 @@ pub(crate) fn get_buffer_create<'ob>(
     match buffer_or_name.untag() {
         Object::String(x) => {
             let name = x.try_into()?;
-            let mut buffer_list = BUFFERS.lock().unwrap();
+            let mut buffer_list = buffers().lock().unwrap();
             match buffer_list.get(name) {
                 Some(b) => Ok(cx.add(*b)),
                 None => {
@@ -100,7 +105,7 @@ pub(crate) fn get_buffer<'ob>(buffer_or_name: GcObj<'ob>, cx: &'ob Context) -> R
     match buffer_or_name.untag() {
         Object::String(x) => {
             let name: &str = x.try_into()?;
-            let buffer_list = BUFFERS.lock().unwrap();
+            let buffer_list = buffers().lock().unwrap();
             match buffer_list.get(name) {
                 Some(b) => Ok(cx.add(*b)),
                 None => Ok(nil()),
@@ -125,7 +130,7 @@ pub(crate) fn get_buffer<'ob>(buffer_or_name: GcObj<'ob>, cx: &'ob Context) -> R
 #[defun]
 fn generate_new_buffer_name(name: &str, ignore: Option<&str>) -> String {
     // check if the name exists
-    let buffer_list = BUFFERS.lock().unwrap();
+    let buffer_list = buffers().lock().unwrap();
     let valid_name =
         |name: &str| ignore.is_some_and(|x| x == name) || !buffer_list.contains_key(name);
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{
-        env::{Env, INTERNED_SYMBOLS},
+        env::{interned_symbols, Env},
         error::{Type, TypeError},
         gc::{Context, Rt},
         object::{nil, Gc, GcObj, LispBuffer, Object},
@@ -9,12 +9,18 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use fn_macros::defun;
-use std::sync::LazyLock;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 
 // static hashmap containing all the buffers
-static BUFFERS: LazyLock<Mutex<HashMap<String, &'static LispBuffer>>> =
-    LazyLock::new(|| Mutex::new(HashMap::default()));
+static BUFFERS: OnceLock<Mutex<HashMap<String, &'static LispBuffer>>> = OnceLock::new();
+
+/// Helper function to avoid calling `get_or_init` on each of the calls to `lock()` on the Mutex.
+///
+/// TODO: Use `LazyLock`: https://github.com/CeleritasCelery/rune/issues/34
+fn buffers() -> &'static Mutex<HashMap<String, &'static LispBuffer>> {
+    BUFFERS.get_or_init(|| Mutex::new(HashMap::default()))
+}
 
 #[defun]
 pub(crate) fn set_buffer<'ob>(
@@ -32,7 +38,7 @@ fn resolve_buffer<'ob>(buffer_or_name: GcObj, cx: &'ob Context) -> Result<&'ob L
         Object::Buffer(b) => Ok(b),
         Object::String(s) => {
             let name: &str = s.try_into()?;
-            let buffer_list = BUFFERS.lock().unwrap();
+            let buffer_list = buffers().lock().unwrap();
             let Some(buffer) = buffer_list.get(name) else {
                 bail!("No buffer named {}", name);
             };
@@ -70,14 +76,14 @@ pub(crate) fn get_buffer_create<'ob>(
     match buffer_or_name.untag() {
         Object::String(x) => {
             let name = x.try_into()?;
-            let mut buffer_list = BUFFERS.lock().unwrap();
+            let mut buffer_list = buffers().lock().unwrap();
             match buffer_list.get(name) {
                 Some(b) => Ok(cx.add(*b)),
                 None => {
                     // If not already in the global buffer list, create a new
                     // buffer and add it
                     let buffer: &'static _ = {
-                        let global = INTERNED_SYMBOLS.lock().unwrap();
+                        let global = interned_symbols().lock().unwrap();
                         let buffer = global.create_buffer(name);
                         // SAFETY: This can be 'static because it is stored in the
                         // global block. Eventually it will be garbage collected
@@ -98,7 +104,7 @@ pub(crate) fn get_buffer<'ob>(buffer_or_name: GcObj<'ob>, cx: &'ob Context) -> R
     match buffer_or_name.untag() {
         Object::String(x) => {
             let name: &str = x.try_into()?;
-            let buffer_list = BUFFERS.lock().unwrap();
+            let buffer_list = buffers().lock().unwrap();
             match buffer_list.get(name) {
                 Some(b) => Ok(cx.add(*b)),
                 None => Ok(nil()),
@@ -123,7 +129,7 @@ pub(crate) fn get_buffer<'ob>(buffer_or_name: GcObj<'ob>, cx: &'ob Context) -> R
 #[defun]
 fn generate_new_buffer_name(name: &str, ignore: Option<&str>) -> String {
     // check if the name exists
-    let buffer_list = BUFFERS.lock().unwrap();
+    let buffer_list = buffers().lock().unwrap();
     let valid_name =
         |name: &str| ignore.is_some_and(|x| x == name) || !buffer_list.contains_key(name);
 

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -1081,7 +1081,6 @@ mod test {
         use OpCode::*;
         let roots = &RootSet::default();
         let cx = &mut Context::new(roots);
-        lazy_static::initialize(&crate::core::env::INTERNED_SYMBOLS);
         // (lambda (x) (symbol-name x))
         make_bytecode!(
             bytecode,
@@ -1124,7 +1123,6 @@ mod test {
         use OpCode::*;
         let roots = &RootSet::default();
         let cx = &mut Context::new(roots);
-        lazy_static::initialize(&crate::core::env::INTERNED_SYMBOLS);
 
         // (lambda () (let ((load-path 5)) load-path))
         make_bytecode!(
@@ -1207,7 +1205,6 @@ mod test {
     #[test]
     fn test_handlers() {
         use OpCode::*;
-        lazy_static::initialize(&crate::core::env::INTERNED_SYMBOLS);
 
         let roots = &RootSet::default();
         let cx = &mut Context::new(roots);

--- a/src/core/env.rs
+++ b/src/core/env.rs
@@ -305,7 +305,6 @@ mod test {
     fn symbol_func() {
         let roots = &RootSet::default();
         let cx = &Context::new(roots);
-        lazy_static::initialize(&INTERNED_SYMBOLS);
         let inner = SymbolCell::new("foo");
         let sym = unsafe { fix_lifetime(Symbol::new(&inner)) };
         assert_eq!("foo", sym.name());

--- a/src/core/env.rs
+++ b/src/core/env.rs
@@ -272,7 +272,7 @@ include!(concat!(env!("OUT_DIR"), "/sym.rs"));
 
 /// Intern a new symbol based on `name`
 pub(crate) fn intern<'ob>(name: &str, cx: &'ob Context) -> Symbol<'ob> {
-    INTERNED_SYMBOLS.lock().unwrap().intern(name, cx)
+    interned_symbols().lock().unwrap().intern(name, cx)
 }
 
 #[cfg(test)]

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -496,7 +496,7 @@ fn require<'ob>(
 ) -> Result<Symbol<'ob>> {
     // TODO: Fix this unsafe into_root
     let feat = unsafe { feature.get(cx).into_root() };
-    if crate::data::FEATURES.lock().unwrap().contains(&feat) {
+    if crate::data::features().lock().unwrap().contains(&feat) {
         return Ok(feature.get(cx));
     }
     let file = match filename {

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -496,7 +496,7 @@ fn require<'ob>(
 ) -> Result<Symbol<'ob>> {
     // TODO: Fix this unsafe into_root
     let feat = unsafe { feature.get(cx).into_root() };
-    if crate::data::features().lock().unwrap().contains(&feat) {
+    if crate::data::FEATURES.lock().unwrap().contains(&feat) {
         return Ok(feature.get(cx));
     }
     let file = match filename {

--- a/src/lread.rs
+++ b/src/lread.rs
@@ -182,7 +182,7 @@ pub(crate) fn intern_soft(string: GcObj, obarray: Option<()>) -> Result<Symbol> 
             }
         }
         Object::String(string) => {
-            let map = crate::core::env::INTERNED_SYMBOLS.lock().unwrap();
+            let map = crate::core::env::interned_symbols().lock().unwrap();
             match map.get(string.try_into()?) {
                 Some(sym) => Ok(unsafe { sym.with_lifetime() }),
                 None => Ok(sym::NIL),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(lazy_cell)]
 #[macro_use]
 mod macros;
 #[macro_use]
@@ -43,9 +44,6 @@ fn main() {
 
     let args = Args::parse();
 
-    // Ensure this is always initalized before anything else. We need this to
-    // code to run to properly initialize the symbol table.
-    lazy_static::initialize(&crate::core::env::INTERNED_SYMBOLS);
     crate::core::env::init_variables(cx, env);
     crate::data::defalias(intern("not", cx), (sym::NULL).into(), None)
         .expect("null should be defined");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(lazy_cell)]
 #[macro_use]
 mod macros;
 #[macro_use]


### PR DESCRIPTION
Hi there!

Here's my first contribution on the repo, and wanted to take the chance to take a small task that would need doing eventually (if not, for consistency with the rest of the Rust world): Migrating off `lazy_static` to the std once_cell, included in Rust 1.70.0 ([docs](https://doc.rust-lang.org/std/cell/index.html)).

I wrote about this contribution while I investigated the code base on this post, in case you are interested about the investigation and code decisions: https://enriquekesslerm.com/blog/bye-lazy-static-welcome-once-cell/

This pull request also opens the discussion about the inclusion of Nightly features on the code base or not. Depending on where we will take this code base, I believe it's worth considering, or just sticking to stable. The discussion opens up with the two commits I sent:

1. On the first commit, I start small with the `buffer.rs` and `data.rs` static: BUFFERS and FEATURES. On that commit, I don't use anything nightly, and as you'll see, we have to create a helper method to avoid including `get_or_init` on each of the BUFFERS or FEATURES calls.
2. On the second commit, I move on to build.rs, slightly more complex (great, had the chance to learn about the custom build we run on the repo) and used the [LazyLock API](https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html), still nightly: gated behind the `lazy_cell` feature flag.

Let's continue the conversation directly on the Pull Request! Happy to modify the code with any feedback from the Pull Request, although I'll have limited availability throughout the week (probably be able to respond the most during the weekends).

Best,
Quique.