### PR TITLE
Modify CI to run directed-minimal-versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,8 +65,6 @@ jobs:
     # Cargo build order. See also
     # https://github.com/jonhoo/fantoccini/blob/fde336472b712bc7ebf5b4e772023a7ba71b2262/Cargo.toml#L47-L49.
     # This action is run on ubuntu with the stable toolchain, as it is not expected to fail
-    # disable this job until we can fix it.
-    if: false
     runs-on: ubuntu-latest
     name: ubuntu / stable / minimal-versions
     steps:
@@ -77,14 +75,14 @@ jobs:
         run: sudo apt-get -y install libpango1.0-dev libgtk-3-dev
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
-      - name: Install nightly for -Zminimal-versions
+      - name: Install nightly for -Zdirected-minimal-versions
         uses: dtolnay/rust-toolchain@nightly
       - name: rustup default stable
         run: rustup default stable
-      - name: cargo update -Zminimal-versions
-        run: cargo +nightly update -Zminimal-versions
-      - name: cargo test
-        run: cargo test --workspace --locked --all-features
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - name: Check directed-minimal-versions
+        run: cargo minimal-versions check --direct
   os-check:
     # run cargo test on mac and windows
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,9 @@ default = []
 debug_bytecode = []
 
 [build-dependencies]
-syn = "2.0" 
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = "2.0.15"
+quote = "1.0.26"
+proc-macro2 = "1.0.60"
 
 [workspace.lints.rust]
 macro_use_extern_crate = "deny"

--- a/fn_macros/Cargo.toml
+++ b/fn_macros/Cargo.toml
@@ -9,10 +9,10 @@ path = "lib.rs"
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
+quote = "1.0.26"
 darling = "0.20"
-syn = { version = "2.0", features = ["full"]}
-proc-macro2 = "1.0"
+syn = { version = "2.0.15", features = ["full"]}
+proc-macro2 = "1.0.60"
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Change Summary

`-Zdirected-minimal-versions` will run with the minimal versions of the specified direct dependencies (of rune and all workspace crates), but the maximum indirect dependencies. This means that we won't fail CI for any issues our direct deps have with `-Zminimal-versions`.

Additionally, fixed some of the versions that were selected for syn, quote and proc-macro2. It's recommended to use qualified versions, to avoid issues with minimal versions.

## Risks associated with this change

I don't really see a risk of taking a dependency on`-Zdirected-minimal-versions`. Here's the documentation, and why I think it's particularly useful for our crate (s, as it counts the workspace). Taiki Endo is also the creator of cargo-hack, which we also plan to use here.

> When a Cargo.lock file is generated, the -Z direct-minimal-versions flag will resolve the dependencies to the minimum SemVer version that will satisfy the requirements (instead of the greatest version) for direct dependencies only.
>
> The intended use-case of this flag is to check, during continuous integration, that the versions specified in Cargo.toml are a correct reflection of the minimum versions that you are actually using. That is, if Cargo.toml says foo = "1.0.0" that you don’t accidentally depend on features added only in foo 1.5.0.
>
> Indirect dependencies are resolved as normal so as not to be blocked on their minimal version validation.

[source]https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#direct-minimal-versions)

## Testing

Ran CI on my own commit on my fork, you can find the test run here: https://github.com/Qkessler/rune/actions/runs/7072080397/job/19250513320