### PR TITLE
Make Trace be cross-crate compatible

### DIFF
--- a/crates/rune-macros/trace.rs
+++ b/crates/rune-macros/trace.rs
@@ -107,16 +107,14 @@ pub(crate) fn expand(orig: &syn::DeriveInput) -> TokenStream {
     quote! {
         #derive
 
-        impl std::ops::Deref for #rt<#orig_name #static_generics> {
+        impl crate::core::gc::RootedDeref for #orig_name #static_generics {
             type Target = #rooted_name #static_generics;
-            fn deref(&self) -> &Self::Target {
-                unsafe { &*(self as *const Self).cast::<Self::Target>() }
-            }
-        }
 
-        impl std::ops::DerefMut for #rt<#orig_name #static_generics> {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                unsafe { &mut *(self as *mut Self).cast::<Self::Target>() }
+            fn rooted_deref(rooted: &crate::core::gc::Rt<Self>) -> &Self::Target {
+                unsafe { &*(rooted as *const crate::core::gc::Rt<Self>).cast::<Self::Target>() }            }
+
+            fn rooted_derefmut(rooted: &mut crate::core::gc::Rt<Self>) -> &mut Self::Target {
+                unsafe { &mut *(rooted as *mut crate::core::gc::Rt<Self>).cast::<Self::Target>() }
             }
         }
     }


### PR DESCRIPTION
## Change Summary

This is a key and PRable part of the effort of refactoring the core out of the main crate to an auxiliar crate, imported
by all the other levels: rune_core.

To avoid the orphan rule (See [RFC 1023 - rebalancing
coherence](https://github.com/rust-lang/rfcs/blob/master/text/1023-rebalancing-coherence.md)) we can't implement foreign
traits for foreign types. A plain example is us implementing `Deref` and `DerefMut` for the "future" foreign type
`Rt`. As `Rt` (with the core refactor) would now be foreign, we fall into the orphan rule.

We overcome that limitation by introducing a trait that would act as the foreign trait, but the key difference is that
we are now implementing it on the actual type `T`, not the rooted type `Rt<T>`, as part of the `Trace` macro.

When types now derive the `Trace` macro, we implement `RootedDeref` and whenever the rooted types need to access `deref`
or `deref_mut`, they are able to do so, as we also implement blanket implementations below it, for all rooted types
`Rt<T>`.

All of this and more discussions are part of this issue: https://github.com/CeleritasCelery/rune/issues/42

## Risks associated with this change

No risks, because as of now, nothing has changed in the structure of the crate. We'll need to make `Rt` public either way, because it's used on the main crate and the core, both.

## Testing
Ran CI as part of the master branch of my fork. You can see the test run here: https://github.com/Qkessler/rune/actions/runs/7140915106
