### PR TITLE
Create initial rune-core crate with only hashmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,43 +9,64 @@ edition = "2021"
 [workspace]
 members = [
   "crates/text-buffer",
-  "crates/rune-macros"
+  "crates/rune-macros",
+  "crates/rune-core"
 ]
-
-[workspace.dependencies]
-quote = "1.0.26"
-syn = { version = "2.0.15", features = ["full"]}
 
 [workspace.package]
 edition = "2021"
 
-[dependencies]
+[workspace.dependencies]
+syn = { version = "2.0.15", features = ["full"] }
+quote = "1.0.26"
+proc-macro2 = "1.0.60"
 anyhow = "1.0.69"
+sptr = "0.3.2"
+fallible-iterator = "0.3.0"
+fallible-streaming-iterator = "0.1.9"
+fxhash = "0.2.1"
+indexmap = "2.1.0"
+memoffset = "0.9.0"
 bstr = "1.3.0"
+float-cmp = "0.9.0"
+
+text-buffer = { version = "0.1.0", path = "crates/text-buffer" }
+rune-core = { version = "0.1.0", path = "crates/rune-core" }
+rune-macros = { version = "0.1.0", path = "crates/rune-macros" }
+
+[dependencies]
+anyhow = { workspace = true }
+bstr = { workspace = true }
 bytecount = "0.6.3"
 druid = "0.8.3"
 fancy-regex = "0.12.0"
-float-cmp = "0.9.0"
+float-cmp = { workspace = true }
 hostname = "0.3.1"
-memoffset = "0.9.0"
+memoffset = { workspace = true }
 num_enum = "0.7.1"
 paste = "1.0.12"
 rand = "0.8.5"
-rune-macros = { version = "0.1.0", path = "crates/rune-macros" }
-sptr = "0.3.2"
+sptr = { workspace = true }
 streaming-iterator = "0.1.9"
-text-buffer = { version = "0.1.0", path = "crates/text-buffer" }
 titlecase = "2.2.1"
-fallible-iterator = "0.3.0"
-fallible-streaming-iterator = "0.1.9"
-indexmap = "2.1.0"
-fxhash = "0.2.1"
+fallible-iterator = { workspace = true }
+fallible-streaming-iterator = { workspace = true }
+indexmap = { workspace = true }
+fxhash = { workspace = true }
+
+text-buffer = { workspace = true }
+rune-macros = { workspace = true }
+rune-core = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"
 
 # [dev-dependencies]
 # backtrace-on-stack-overflow = "0.3.0"
+
+[build-dependencies]
+syn = { workspace = true }
+quote = { workspace = true }
 
 [profile.dev.build-override]
 opt-level = 3
@@ -56,11 +77,6 @@ debug = true
 [features]
 default = []
 debug_bytecode = []
-
-[build-dependencies]
-quote = { workspace = true}
-syn = { workspace = true }
-proc-macro2 = "1.0.60"
 
 [workspace.lints.rust]
 macro_use_extern_crate = "deny"

--- a/crates/rune-core/Cargo.toml
+++ b/crates/rune-core/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "rune-core"
+version = "0.1.0"
+description = "Core functionality of the Rune Emacs Runtime."
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true }
+bstr = { workspace = true }
+sptr = { workspace = true }
+fallible-iterator = { workspace = true }
+fallible-streaming-iterator = { workspace = true }
+float-cmp = { workspace = true }
+fxhash = { workspace = true }
+indexmap = { workspace = true }
+memoffset = { workspace = true }
+
+rune-macros = { workspace = true }
+text-buffer = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rune-core/src/hashmap.rs
+++ b/crates/rune-core/src/hashmap.rs
@@ -1,0 +1,6 @@
+//! Hashmap types used in the crate.
+use fxhash::FxBuildHasher;
+
+pub type HashMap<K, V> = std::collections::HashMap<K, V, FxBuildHasher>;
+pub type HashSet<K> = std::collections::HashSet<K, FxBuildHasher>;
+pub type IndexMap<K, V> = indexmap::IndexMap<K, V, FxBuildHasher>;

--- a/crates/rune-core/src/lib.rs
+++ b/crates/rune-core/src/lib.rs
@@ -1,0 +1,2 @@
+//! Core functionality of the Rune Runtime.
+pub mod hashmap;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,14 +1,12 @@
 //! Buffer operations.
-use crate::{
-    core::{
-        env::{interned_symbols, Env},
-        error::{Type, TypeError},
-        gc::{Context, Rt},
-        object::{nil, Gc, GcObj, LispBuffer, Object},
-    },
-    hashmap::HashMap,
+use crate::core::{
+    env::{interned_symbols, Env},
+    error::{Type, TypeError},
+    gc::{Context, Rt},
+    object::{nil, Gc, GcObj, LispBuffer, Object},
 };
 use anyhow::{bail, Result};
+use rune_core::hashmap::HashMap;
 use rune_macros::defun;
 use std::sync::Mutex;
 use std::sync::OnceLock;

--- a/src/core/cons.rs
+++ b/src/core/cons.rs
@@ -1,4 +1,4 @@
-use crate::hashmap::HashSet;
+use rune_core::hashmap::HashSet;
 
 use super::gc::{Block, Context, GcManaged, GcMark, Trace};
 use super::object::{nil, CloneIn, Gc, GcObj, IntoObject, ObjCell, Object, RawObj};

--- a/src/core/env.rs
+++ b/src/core/env.rs
@@ -1,8 +1,8 @@
 #![allow(unstable_name_collisions)]
 use super::gc::{Block, Context, Rt};
 use super::object::{CloneIn, Function, Gc, GcObj, LispBuffer, OpenBuffer, WithLifetime};
-use crate::hashmap::HashMap;
 use anyhow::{anyhow, Result};
+use rune_core::hashmap::HashMap;
 use rune_macros::Trace;
 use std::sync::Mutex;
 

--- a/src/core/gc/root.rs
+++ b/src/core/gc/root.rs
@@ -5,7 +5,7 @@ use super::super::{
 use super::{Block, Context, RootSet, Trace};
 use crate::core::env::Symbol;
 use crate::core::object::{Gc, IntoObject, LispString, Object, Untag, WithLifetime};
-use crate::hashmap::{HashMap, HashSet};
+use rune_core::hashmap::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut, Index, IndexMut};
 use std::slice::SliceIndex;
 use std::{

--- a/src/core/gc/trace.rs
+++ b/src/core/gc/trace.rs
@@ -1,5 +1,5 @@
 use super::super::object::RawObj;
-use crate::hashmap::{HashMap, HashSet};
+use rune_core::hashmap::{HashMap, HashSet};
 
 pub(crate) trait Trace {
     fn trace(&self, stack: &mut Vec<RawObj>);

--- a/src/core/object/hashtable.rs
+++ b/src/core/object/hashtable.rs
@@ -1,6 +1,6 @@
 use super::{CloneIn, Gc, GcObj, IntoObject, ObjCell};
 use crate::core::gc::{GcManaged, GcMark, Trace};
-use crate::hashmap::{HashSet, IndexMap};
+use rune_core::hashmap::{HashSet, IndexMap};
 use std::cell::{BorrowMutError, Ref, RefCell, RefMut};
 use std::fmt::{self, Debug, Display, Write};
 

--- a/src/core/object/tagged.rs
+++ b/src/core/object/tagged.rs
@@ -11,9 +11,10 @@ use super::{
 use super::{
     ByteFn, HashTable, LispFloat, LispHashTable, LispString, LispVec, Record, RecordBuilder, SubrFn,
 };
+use crate::core::env::sym;
 use crate::core::gc::{GcManaged, Trace};
-use crate::{core::env::sym, hashmap::HashSet};
 use private::{Tag, TaggedPtr};
+use rune_core::hashmap::HashSet;
 use sptr::Strict;
 use std::fmt;
 use std::marker::PhantomData;

--- a/src/core/object/vector.rs
+++ b/src/core/object/vector.rs
@@ -1,9 +1,7 @@
 use super::{CloneIn, Gc, GcObj, IntoObject, MutObjCell, ObjCell};
-use crate::{
-    core::gc::{Block, GcManaged, GcMark, Trace},
-    hashmap::HashSet,
-};
+use crate::core::gc::{Block, GcManaged, GcMark, Trace};
 use anyhow::{anyhow, Result};
+use rune_core::hashmap::HashSet;
 use std::{
     fmt::{self, Write},
     mem,

--- a/src/data.rs
+++ b/src/data.rs
@@ -6,8 +6,8 @@ use crate::core::{
     gc::{Context, IntoRoot, Rt},
     object::{nil, Gc, GcObj, List, Number, Object, SubrFn},
 };
-use crate::hashmap::HashSet;
 use anyhow::{anyhow, Result};
+use rune_core::hashmap::HashSet;
 use rune_macros::defun;
 use std::sync::Mutex;
 use std::sync::OnceLock;

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -1,6 +1,0 @@
-//! Hashmap types used in the crate.
-use fxhash::FxBuildHasher;
-
-pub(crate) type HashMap<K, V> = std::collections::HashMap<K, V, FxBuildHasher>;
-pub(crate) type HashSet<K> = std::collections::HashSet<K, FxBuildHasher>;
-pub(crate) type IndexMap<K, V> = indexmap::IndexMap<K, V, FxBuildHasher>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@ mod fileio;
 mod floatfns;
 mod fns;
 mod gui;
-mod hashmap;
 mod interpreter;
 mod keymap;
 mod lread;


### PR DESCRIPTION
## Change Summary

This is the first step to refactor the core out of the main crate. The idea with this PR is to **just** include the changes on the crate structure itself, with a sample module moved to core. The idea with separating the PRs that I do
for this refactoring is to make the whole process easier to review + making sure there are no regressions on the refactors we do.

I started moving hashmap, which is typing that is used both in rune-core and the main crate, hence why moved to rune-core. I'll move other modules to rune-core little by little, as we get closer with PRs.

## Risks associated with this change
There isn't a risk, we are just refactoring and we can verify no regressions with CI.

## Testing
Ran CI on my master branch, with everything passing. I expect the CI as part of the PR to be passing as well.
