### PR TITLE
Add macros core module

### DIFF
--- a/crates/rune-core/src/lib.rs
+++ b/crates/rune-core/src/lib.rs
@@ -1,2 +1,3 @@
 //! Core functionality of the Rune Runtime.
 pub mod hashmap;
+pub mod macros;

--- a/crates/rune-core/src/macros.rs
+++ b/crates/rune-core/src/macros.rs
@@ -1,0 +1,205 @@
+//! Redefinition of the `macro_exported` macros to avoid namespace
+//! colision when the macros have the same name as modules.
+//!
+//! An example of that is the `crate::error` module, and the [`macro@error`] macro.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __define_unbox {
+    ($ident:ident, $ty:ty) => {
+        define_unbox!($ident, $ident, $ty);
+    };
+    ($ident:ident, $ty:ident, $self:ty) => {
+        #[allow(unused_qualifications)]
+        impl<'ob> std::convert::TryFrom<crate::object::GcObj<'ob>> for $self {
+            type Error = crate::error::TypeError;
+            fn try_from(obj: crate::object::GcObj<'ob>) -> Result<Self, Self::Error> {
+                match obj.untag() {
+                    crate::object::Object::$ident(x) => Ok(x),
+                    _ => Err(crate::error::TypeError::new(crate::error::Type::$ty, obj)),
+                }
+            }
+        }
+        #[allow(unused_qualifications)]
+        impl<'ob> std::convert::TryFrom<crate::object::GcObj<'ob>> for Option<$self> {
+            type Error = crate::error::TypeError;
+            fn try_from(obj: crate::object::GcObj<'ob>) -> Result<Self, Self::Error> {
+                match obj.untag() {
+                    crate::object::Object::NIL => Ok(None),
+                    crate::object::Object::$ident(x) => Ok(Some(x)),
+                    _ => Err(crate::error::TypeError::new(crate::error::Type::$ty, obj)),
+                }
+            }
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __cons {
+    ($car:expr, $cdr:expr; $cx:expr) => {
+        $cx.add({
+            let car = $cx.add($car);
+            let cdr = $cx.add($cdr);
+            unsafe { crate::core::cons::Cons::new_unchecked(car, cdr) }
+        })
+    };
+    ($car:expr; $cx:expr) => {
+        $cx.add({
+            let car = $cx.add($car);
+            unsafe { crate::core::cons::Cons::new_unchecked(car, crate::core::object::nil()) }
+        })
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __list {
+        ($x:expr; $cx:expr) => ($crate::macros::cons!($x; $cx));
+        ($x:expr, $($y:expr),+ $(,)? ; $cx:expr) => ($crate::macros::cons!($x, list!($($y),+ ; $cx) ; $cx));
+    }
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __error {
+        ($msg:literal $(,)?  $($args:expr),* $(,)?) => (crate::core::error::EvalError::new_error(anyhow::anyhow!($msg, $($args),*)));
+        ($err:expr) => (crate::core::error::EvalError::new($err));
+    }
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __bail_err {
+        ($($args:expr),* $(,)?) => (return Err($crate::macros::error!($($args),*)));
+    }
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __root {
+    ($ident:ident, $cx:ident) => {
+        rune_core::macros::root!(
+            $ident,
+            unsafe { crate::core::gc::IntoRoot::into_root($ident) },
+            $cx
+        );
+    };
+    // When using this form, `value` should be an intializer that does not need `IntoRoot`
+    ($ident:ident, $value:expr, $cx:ident) => {
+        let mut rooted = $value;
+        let mut root =
+            unsafe { crate::core::gc::__StackRoot::new(&mut rooted, $cx.get_root_set()) };
+        let $ident = root.as_mut();
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __rooted_iter {
+    ($ident:ident, $value:expr, $cx:ident) => {
+        // Create roots, but don't initialize them
+        let mut elem;
+        let mut cons;
+        let mut root_elem;
+        let mut root_cons;
+        // use match to ensure that $value is not evaled inside the unsafe block
+        let list: crate::core::object::Gc<crate::core::object::List> = match $value {
+            // Convert the value into a list
+            value => unsafe { crate::core::gc::IntoRoot::into_root(value).try_into()? },
+        };
+        #[allow(unused_qualifications, unused_mut)]
+        let mut $ident = if let crate::core::object::List::Cons(head) = list.untag() {
+            use crate::core::{cons, gc, object};
+            // If the list is not empty, then initialize the roots and put them
+            // in the stack space reserved
+            unsafe {
+                elem = object::nil();
+                cons = object::WithLifetime::with_lifetime(head);
+                root_elem = gc::__StackRoot::new(&mut elem, $cx.get_root_set());
+                root_cons = gc::__StackRoot::new(&mut cons, $cx.get_root_set());
+                cons::ElemStreamIter::new(Some(root_elem.as_mut()), Some(root_cons.as_mut()))
+            }
+        } else {
+            crate::core::cons::ElemStreamIter::new(None, None)
+        };
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __last {
+    ($arg:expr) => { $arg };
+    ($head:expr, $($rest:expr),+) => {
+        $crate::macros::last!($($rest),+)
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __rebind {
+    // rebind!(func(x, cx)?)
+    ($($path:ident).*($($arg:expr),+)$($x:tt)?) => {{
+        rebind!($($path).*($($arg),+)$($x)?, $crate::macros::last!($($arg),+))
+    }};
+    // rebind!(func(x, cx).unwrap())
+    ($($path:ident).*($($arg:expr),+).unwrap()) => {{
+        rebind!($($path).*($($arg),+).unwrap(), $crate::macros::last!($($arg),+))
+    }};
+    // rebind!(x, cx)
+    ($value:expr, $cx:expr) => {{
+        // Eval value outside the unsafe block
+        let unbound = match $value {
+            v => unsafe { crate::core::object::WithLifetime::<'static>::with_lifetime(v) }
+        };
+        $cx.bind(unbound)
+    }};
+}
+
+/// TODO: Document
+#[doc(inline)]
+pub use __bail_err as bail_err;
+
+/// TODO: Document
+#[doc(inline)]
+pub use __cons as cons;
+
+/// TODO: Document
+#[doc(inline)]
+pub use __define_unbox as define_unbox;
+
+/// TODO: Document
+#[doc(inline)]
+pub use __error as error;
+
+/// TODO: Document
+#[doc(inline)]
+pub use __list as list;
+
+/// Helper macro for the `rebind!` macro
+#[doc(inline)]
+pub use __last as last;
+
+/// Rebinds an object so that it is bound to an immutable borrow of `crate::gc::Context`
+/// instead of a mutable borrow. This can release the mutable borrow and allow
+/// Context to be used for other things.
+///
+/// # Examples
+///
+/// ```ignore
+/// let object = rebind!(func1(&mut cx));
+/// func2(&mut cx);
+/// let object2 = object;
+/// ```
+///
+/// wthout this macro the above code would not compile because `object` can't
+/// outlive the call to func2.
+#[doc(inline)]
+pub use __rebind as rebind;
+
+/// Creates a new root that will be traced during garbage collection. The value
+/// returned by this macro is no longer bound to the `Context` and so can be
+/// used outside of the `Context`'s lifetime. The root is tied to the stack, and
+/// will be unrooted when it goes out of scope.
+#[doc(inline)]
+pub use __root as root;
+
+/// TODO: Document
+#[doc(inline)]
+pub use __rooted_iter as rooted_iter;

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -5,6 +5,7 @@ use crate::core::object::{
     nil, ByteFn, FnArgs, Gc, GcObj, IntoObject, LispString, LispVec, RecordBuilder,
 };
 use anyhow::{ensure, Result};
+use rune_core::macros::cons;
 use rune_macros::defun;
 
 #[defun]

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -3,9 +3,9 @@ use crate::core::env::{sym, Env, Symbol};
 use crate::core::error::{ErrorType, EvalError, EvalResult};
 use crate::core::gc::{Context, Rt};
 use crate::core::object::{nil, ByteFn, Gc, GcObj, LispString, LispVec, Object, WithLifetime};
-use crate::root;
 use anyhow::{bail, Result};
 use bstr::ByteSlice;
+use rune_core::macros::{bail_err, cons, rebind, root};
 use rune_macros::{defun, Trace};
 
 mod opcode;
@@ -874,6 +874,7 @@ mod test {
         gc::RootSet,
         object::{HashTable, IntoObject, LispVec},
     };
+    use rune_core::macros::{cons, list, rebind, root};
 
     use super::{opcode::OpCode, *};
 

--- a/src/core/cons.rs
+++ b/src/core/cons.rs
@@ -180,32 +180,10 @@ impl Cons {
 
 define_unbox!(Cons, &'ob Cons);
 
-#[macro_export]
-macro_rules! cons {
-    ($car:expr, $cdr:expr; $cx:expr) => {
-        $cx.add({
-            let car = $cx.add($car);
-            let cdr = $cx.add($cdr);
-            unsafe { $crate::core::cons::Cons::new_unchecked(car, cdr) }
-        })
-    };
-    ($car:expr; $cx:expr) => {
-        $cx.add({
-            let car = $cx.add($car);
-            unsafe { $crate::core::cons::Cons::new_unchecked(car, $crate::core::object::nil()) }
-        })
-    };
-}
-
-#[macro_export]
-macro_rules! list {
-    ($x:expr; $cx:expr) => ($crate::cons!($x; $cx));
-    ($x:expr, $($y:expr),+ $(,)? ; $cx:expr) => ($crate::cons!($x, list!($($y),+ ; $cx) ; $cx));
-}
-
 #[cfg(test)]
 mod test {
     use crate::core::gc::Context;
+    use rune_core::macros::{cons, list};
 
     use super::super::gc::RootSet;
     use super::*;

--- a/src/core/env.rs
+++ b/src/core/env.rs
@@ -3,6 +3,7 @@ use super::gc::{Block, Context, Rt};
 use super::object::{CloneIn, Function, Gc, GcObj, LispBuffer, OpenBuffer, WithLifetime};
 use anyhow::{anyhow, Result};
 use rune_core::hashmap::HashMap;
+use rune_core::macros::list;
 use rune_macros::Trace;
 use std::sync::Mutex;
 
@@ -281,7 +282,7 @@ pub(crate) fn intern<'ob>(name: &str, cx: &'ob Context) -> Symbol<'ob> {
 
 #[cfg(test)]
 mod test {
-    use crate::root;
+    use rune_core::macros::{cons, list, root};
 
     use super::*;
 

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -116,17 +116,6 @@ impl From<std::convert::Infallible> for EvalError {
     }
 }
 
-#[macro_export]
-macro_rules! error {
-    ($msg:literal $(,)?  $($args:expr),* $(,)?) => ($crate::core::error::EvalError::new_error(anyhow::anyhow!($msg, $($args),*)));
-    ($err:expr) => ($crate::core::error::EvalError::new($err));
-}
-
-#[macro_export]
-macro_rules! bail_err {
-    ($($args:expr),* $(,)?) => (return Err(error!($($args),*)));
-}
-
 pub(crate) type EvalResult<'ob> = Result<GcObj<'ob>, EvalError>;
 
 /// The function or form has the wrong number of arguments.

--- a/src/core/gc/root.rs
+++ b/src/core/gc/root.rs
@@ -112,24 +112,6 @@ impl<T> Drop for __StackRoot<'_, T> {
     }
 }
 
-/// Creates a new root that will be traced during garbage collection. The value
-/// returned by this macro is no longer bound to the `Context` and so can be
-/// used outside of the `Context`'s lifetime. The root is tied to the stack, and
-/// will be unrooted when it goes out of scope.
-#[macro_export]
-macro_rules! root {
-    ($ident:ident, $cx:ident) => {
-        $crate::root!($ident, unsafe { $crate::core::gc::IntoRoot::into_root($ident) }, $cx);
-    };
-    // When using this form, `value` should be an intializer that does not need `IntoRoot`
-    ($ident:ident, $value:expr, $cx:ident) => {
-        let mut rooted = $value;
-        let mut root =
-            unsafe { $crate::core::gc::__StackRoot::new(&mut rooted, $cx.get_root_set()) };
-        let $ident = root.as_mut();
-    };
-}
-
 /// Trait created to overpass the orphan rule when deriving the
 /// [Trace](`rune_macros::Trace`) derive macro. The derive
 /// macro contains a blanket `Deref` (and `DerefMut`) like this:
@@ -572,6 +554,7 @@ impl<T> Deref for Rt<HashSet<T>> {
 #[cfg(test)]
 mod test {
     use crate::core::object::nil;
+    use rune_core::macros::root;
 
     use super::super::RootSet;
     use super::*;

--- a/src/core/gc/trace.rs
+++ b/src/core/gc/trace.rs
@@ -85,7 +85,7 @@ impl<T: Trace> Trace for Option<T> {
 mod test {
     use super::super::super::gc::{Context, RootSet};
     use super::*;
-    use crate::root;
+    use rune_core::macros::root;
 
     struct Foo(u64);
     impl Trace for Foo {

--- a/src/core/object/tagged.rs
+++ b/src/core/object/tagged.rs
@@ -1326,6 +1326,7 @@ impl<'ob> List<'ob> {
 mod test {
     use super::{TagType, MAX_FIXNUM, MIN_FIXNUM};
     use crate::core::gc::{Context, RootSet};
+    use rune_core::macros::list;
 
     #[test]
     fn test_clamp_fixnum() {

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,6 +8,7 @@ use crate::core::{
 };
 use anyhow::{anyhow, Result};
 use rune_core::hashmap::HashSet;
+use rune_core::macros::cons;
 use rune_macros::defun;
 use std::sync::Mutex;
 use std::sync::OnceLock;
@@ -453,7 +454,7 @@ pub(crate) fn setcdr<'ob>(cell: &Cons, newcdr: GcObj<'ob>) -> Result<GcObj<'ob>>
 
 #[defun]
 pub(crate) fn cons<'ob>(car: GcObj, cdr: GcObj, cx: &'ob Context) -> GcObj<'ob> {
-    crate::cons!(car, cdr; cx)
+    cons!(car, cdr; cx)
 }
 
 // Symbol with position

--- a/src/editfns.rs
+++ b/src/editfns.rs
@@ -156,8 +156,8 @@ mod test {
     use crate::{
         buffer::{get_buffer_create, set_buffer},
         core::gc::{Context, RootSet},
-        root,
     };
+    use rune_core::macros::root;
 
     use super::*;
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -9,10 +9,10 @@ use crate::core::{
     object::{Function, Gc, GcObj},
 };
 use crate::fns::{assq, eq};
-use crate::{root, rooted_iter};
 use anyhow::{anyhow, bail, ensure, Result};
 use fallible_iterator::FallibleIterator;
 use fallible_streaming_iterator::FallibleStreamingIterator;
+use rune_core::macros::{list, root, rooted_iter};
 use rune_macros::defun;
 
 #[defun]

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -12,11 +12,11 @@ use crate::{
     },
     data::aref,
 };
-use crate::{root, rooted_iter};
 use anyhow::{bail, Result};
 use bstr::ByteSlice;
 use fallible_iterator::FallibleIterator;
 use fallible_streaming_iterator::FallibleStreamingIterator;
+use rune_core::macros::{cons, list, rebind, root, rooted_iter};
 use rune_macros::defun;
 
 #[defun]
@@ -797,6 +797,7 @@ fn disable_debug() -> bool {
 #[cfg(test)]
 mod test {
     use crate::core::{gc::RootSet, object::qtrue};
+    use rune_core::macros::root;
 
     use super::*;
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -6,12 +6,12 @@ use crate::core::{
     gc::{Context, Rt},
     object::{nil, qtrue, Function, Gc, GcObj, List, Object},
 };
-use crate::{root, rooted_iter};
 use anyhow::Context as _;
 use anyhow::Result as AnyResult;
 use anyhow::{anyhow, bail, ensure};
 use fallible_iterator::FallibleIterator;
 use fallible_streaming_iterator::FallibleStreamingIterator;
+use rune_core::macros::{bail_err, cons, error, rebind, root, rooted_iter};
 use rune_macros::defun;
 
 struct Interpreter<'brw> {
@@ -828,6 +828,7 @@ pub(crate) fn parse_arg_list(
 #[cfg(test)]
 mod test {
     use crate::core::{env::intern, gc::RootSet, object::IntoObject};
+    use rune_core::macros::list;
 
     use super::*;
 

--- a/src/lread.rs
+++ b/src/lread.rs
@@ -5,10 +5,11 @@ use crate::core::error::{Type, TypeError};
 use crate::core::gc::Context;
 use crate::core::gc::Rt;
 use crate::core::object::{nil, Gc, GcObj, LispString, Object, WithLifetime};
+use crate::interpreter;
 use crate::reader;
-use crate::{interpreter, root};
 use anyhow::{anyhow, Context as _};
 use anyhow::{bail, ensure, Result};
+use rune_core::macros::{cons, root};
 use rune_macros::defun;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -207,7 +208,7 @@ mod test {
 
     use super::*;
     use crate::core::gc::RootSet;
-    use crate::root;
+    use rune_core::macros::root;
 
     #[test]
     #[allow(clippy::float_cmp)] // Bug in Clippy

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ use crate::core::{
     gc::{Context, RootSet, Rt},
     object::{nil, Gc, LispString},
 };
+use rune_core::macros::root;
 use std::io::{self, Write};
 
 fn main() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,6 +5,7 @@ use crate::core::{
     object::GcObj,
 };
 use crate::fns;
+use rune_core::macros::list;
 use std::fmt::Display;
 use std::str;
 use std::{fmt, iter::Peekable, str::CharIndices};
@@ -511,6 +512,7 @@ pub(crate) fn read<'ob>(slice: &str, cx: &'ob Context) -> Result<(GcObj<'ob>, us
 #[cfg(test)]
 mod test {
     use crate::core::gc::RootSet;
+    use rune_core::macros::cons;
 
     use super::*;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -161,7 +161,8 @@ fn string_equal(s1: &str, s2: &str) -> bool {
 
 #[cfg(test)]
 mod test {
-    use crate::{core::gc::RootSet, root};
+    use crate::core::gc::RootSet;
+    use rune_core::macros::root;
 
     use super::*;
 

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -1,12 +1,10 @@
 //! Multi-threaded elisp support.
-use crate::{
-    core::{
-        env::Env,
-        gc::{Block, Context, RootSet},
-        object::{CloneIn, GcObj},
-    },
-    root,
+use crate::core::{
+    env::Env,
+    gc::{Block, Context, RootSet},
+    object::{CloneIn, GcObj},
 };
+use rune_core::macros::root;
 use rune_macros::defun;
 use std::thread::{self, JoinHandle};
 

--- a/src/timefns.rs
+++ b/src/timefns.rs
@@ -4,6 +4,7 @@ use crate::core::{
     gc::{Context, Rt},
     object::GcObj,
 };
+use rune_core::macros::list;
 use rune_macros::defun;
 use std::time::SystemTime;
 


### PR DESCRIPTION
## Change Summary

Continued the refactoring of the core modules into the rune-core crate. This PR is adding the macros module, which holds all the macros that are created as part of the core and used across the main crate.

On this module, we reexport all the macros that were previously defined across the main crate. By reexporting under a module (rune_core::macros) we avoid naming conflicts. An example of such conflict is the rune::error module, since there were cases where we needed both the `error!` macro and the `error` module.

By using `#[doc(hidden)]` on the private items, we avoid the private (preffixed with __) to be added to the cargo doc documentation, to avoid missusage of the macros.

## Risks associated with this change
There isn't a risk, we are just refactoring and we can verify no regressions with CI.

## Testing
Ran CI on my master branch, with everything passing. I expect the CI as part of the PR to be passing as well.
