### PR TITLE
Implemented string-bytes, string-lessp, and string-version-lessp

### DIFF
--- a/src/fns.rs
+++ b/src/fns.rs
@@ -809,15 +809,13 @@ pub(crate) fn string_version_lessp(string1: &str, string2: &str) -> bool {
 }
 /// Helper function to create a number from a string iterator
 #[inline]
-fn create_number<I: Iterator<Item = char>>(
-    iter: &mut std::iter::Peekable<I>,
-) -> usize {
+fn create_number<I: Iterator<Item = char>>(iter: &mut std::iter::Peekable<I>) -> usize {
     let mut num = 0;
 
     while let Some(digit) = iter.next_if(|c| c.is_ascii_digit()) {
         num = num * 10 + digit.to_digit(10).unwrap() as usize;
     }
-    
+
     num
 }
 
@@ -1099,7 +1097,7 @@ mod test {
         assert_lisp("(string-version-lessp \"abc\" \"bcd\")", "t");
         // Test Equality with number
         assert_lisp("(string-version-lessp \"less1\" \"less1\")", "nil");
-        assert_lisp("(string-version-lessp \"100a\" \"100b\")", "nil");
+        assert_lisp("(string-version-lessp \"100a\" \"100b\")", "t");
         // Test Differing numeric position does matter
         assert_lisp("(string-version-lessp \"1less\" \"less1\")", "t");
         // Test Greater than numericaly

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -1111,7 +1111,6 @@ mod test {
         assert_lisp("(string-version-lessp \"133less1\" \"less12\")", "t");
         // Test that digits don't disappear
         assert_lisp("(string-version-lessp \"112a\" \"512a\")", "t");
-        
     }
 
     #[test]

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -796,7 +796,7 @@ pub(crate) fn string_version_lessp(string1: &str, string2: &str) -> bool {
         _ => {},
     }
     
-    return string1.len() < string2.len();
+    return char_len1 < char_len2;
 }
 /// Helper function to create a number from a string iterator
 /// c: the current character

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -741,6 +741,11 @@ pub(crate) fn levenshtein_distance<T: PartialEq, I: Iterator<Item = T>>(s1: I, s
     v0[t.len()]
 }
 
+#[defun]
+pub(crate) fn string_bytes(string: &str) -> i64 {
+    string.len() as i64
+}
+
 ///////////////
 // HashTable //
 ///////////////

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -793,6 +793,7 @@ pub(crate) fn string_version_lessp(string1: &str, string2: &str) -> bool {
                 return false;
             }
         }
+        _ => {},
     }
     
     return string1.len() < string2.len();

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -761,43 +761,40 @@ pub(crate) fn string_lessp(string1: &str, string2: &str) -> bool {
 #[defun]
 pub(crate) fn string_version_lessp(string1: &str, string2: &str) -> bool {
     let mut iter1 = string1.chars();
+    let mut char_len1 = 0;
     let mut iter2 = string2.chars();
+    let mut char_len2 = 0;
+    let mut num1 = None;
+    let mut num2 = None;
     while let (Some(mut c1), Some(mut c2)) = (iter1.next(), iter2.next()) {
-        let num1 = create_number(c1, &mut iter1, &mut |c| c1 = c);
-        let num2 = create_number(c2, &mut iter2, &mut |c| c2 = c);
+        char_len1 += 1;
+        char_len2 += 1;
+        num1 = create_number(c1, &mut iter1, &mut |c| {
+            char_len1 += 1;
+            c1 = c
+        });
+        num2 = create_number(c2, &mut iter2, &mut |c| {
+            char_len2 += 1;
+            c2 = c
+        });
 
-        match (num1, num2) {
-            (Some(n1), Some(n2)) => {
-                if n1 < n2 {
-                    return true;
-                } else if n1 > n2 {
-                    return false;
-                }
-            }
-            (Some(n), None) => {
-                if n < c2 as usize {
-                    return true;
-                } else if n > c2 as usize {
-                    return false;
-                }
-            }
-            (None, Some(n)) => {
-                if (c1 as usize) < n {
-                    return true;
-                } else if c1 as usize > n {
-                    return false;
-                }
-            }
-            (None, None) => {
-                if c1 < c2 {
-                    return true;
-                } else if c1 > c2 {
-                    return false;
-                }
+        if c1 < c2 {
+            return true;
+        } else if c1 > c2 {
+            return false;
+        }
+    }
+
+    match (num1, num2) {
+        (Some(n1), Some(n2)) => {
+            if n1 < n2 {
+                return true;
+            } else if n1 > n2 {
+                return false;
             }
         }
-        
     }
+    
     return string1.len() < string2.len();
 }
 /// Helper function to create a number from a string iterator

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -746,6 +746,18 @@ pub(crate) fn string_bytes(string: &str) -> i64 {
     string.len() as i64
 }
 
+#[defun]
+pub(crate) fn string_lessp(string1: &str, string2: &str) -> bool {
+    for (c1, c2) in string1.chars().zip(string2.chars()) {
+        if c1 < c2 {
+            return true;
+        } else if c1 > c2 {
+            return false;
+        }
+    }
+    return false;
+}
+
 ///////////////
 // HashTable //
 ///////////////

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -768,18 +768,21 @@ pub(crate) fn string_version_lessp(string1: &str, string2: &str) -> bool {
     let mut num2 = None;
     //Peeking in order to try to match a pattern without progressing the iterator
     while let (Some(c1), Some(c2)) = (iter1.peek(), iter2.peek()) {
+        // Copying the characters to avoid borrowing the iterator
         let (c1, c2) = (*c1, *c2);
-        iter1.next();
-        iter2.next();
         if c1.is_ascii_digit() {
             num1 = Some(create_number(&mut iter1));
         } else {
             char_len1 += 1;
+            // Progressing the iterator because it wasn't a number
+            iter1.next();
         }
         if c2.is_ascii_digit() {
             num2 = Some(create_number(&mut iter2));
         } else {
             char_len2 += 1;
+            // Progressing the iterator because it wasn't a number
+            iter2.next();
         }
 
         if c1 != c2 {
@@ -1106,6 +1109,9 @@ mod test {
         assert_lisp("(string-version-lessp \"less1\" \"less12\")", "t");
         // Test that later numbers override previous ones
         assert_lisp("(string-version-lessp \"133less1\" \"less12\")", "t");
+        // Test that digits don't disappear
+        assert_lisp("(string-version-lessp \"112a\" \"512a\")", "t");
+        
     }
 
     #[test]

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -804,6 +804,8 @@ pub(crate) fn string_version_lessp(string1: &str, string2: &str) -> bool {
 /// f: a function to update the current character. This is a callback.
 /// Returns the number if it was created, otherwise None
 /// This function is used to parse version numbers in `string-version-lessp`
+/// The callback is so that we can update the length of the string - numbers
+/// and to update the next non-ascii-numeric char
 #[inline]
 fn create_number<I: Iterator<Item = char>, F: FnMut(char) -> ()>(
     mut c: char,
@@ -1085,6 +1087,38 @@ mod test {
         let s2 = "world";
         let distance = levenshtein_distance(&mut s1.chars(), &mut s2.chars());
         assert_eq!(distance, 4);
+    }
+
+    #[test]
+    fn test_string_lessp() {
+        // Test Equality
+        assert_lisp("(string-lessp \"less\" \"less\")", "nil");
+        // Test Length
+        assert_lisp("(string-lessp \"les\" \"less\")", "t");
+        assert_lisp("(string-lessp \"less\" \"les\")", "nil");
+        // Check for less than
+        assert_lisp("(string-lessp \"abc\" \"bcd\")", "t");
+    }
+
+    #[test]
+    fn test_string_version_lessp() {
+        // Test Equality
+        assert_lisp("(string-version-lessp \"less\" \"less\")", "nil");
+        // Test Length 
+        assert_lisp("(string-version-lessp \"les\" \"less\")", "t");
+        assert_lisp("(string-version-lessp \"less\" \"les\")", "nil");
+        // Test for less than
+        assert_lisp("(string-lessp \"abc\" \"bcd\")", "t");
+        // Test Equality with number
+        assert_lisp("(string-version-lessp \"less1\" \"less1\")", "nil");
+        // Test Differing numeric position doesn't matter
+        assert_lisp("(string-version-lessp \"1less\" \"less1\")", "nil");
+        // Test Greater than numericaly
+        assert_lisp("(string-version-lessp \"less12\" \"less1\")", "nil");
+        // Test Less than numericaly
+        assert_lisp("(string-version-lessp \"less1\" \"less12\")", "t");
+        // Test that later numbers override previous ones
+        assert_lisp("(string-version-lessp \"133less1\" \"less12\")", "t");
     }
 
     #[test]


### PR DESCRIPTION
I have completed the last of the string functions that I think I can do properly. The rest require messing with locales or converting between unibyte and multibyte. Then there is `clear-string` which looks like it needs set the length to zero but keep the capacity.