### PR TITLE
Fix for string-version-lessp and string-lessp

### DIFF
--- a/src/core/object/symbol.rs
+++ b/src/core/object/symbol.rs
@@ -25,10 +25,6 @@ mod sealed {
         pub(crate) fn as_bytes(&self) -> &[u8] {
             self.name.as_bytes()
         }
-
-        pub(crate) fn as_str(&self) -> &str {
-            self.name.as_str()
-        }
     }
 }
 
@@ -56,13 +52,6 @@ impl SymbolName {
         match self {
             SymbolName::Interned(x) => x.as_bytes(),
             SymbolName::Uninterned(x) => x.get().as_bytes(),
-        }
-    }
-
-    fn as_str(&self) -> &str {
-        match self {
-            SymbolName::Interned(x) => x,
-            SymbolName::Uninterned(x) => x.get(),
         }
     }
 }

--- a/src/core/object/symbol.rs
+++ b/src/core/object/symbol.rs
@@ -25,6 +25,10 @@ mod sealed {
         pub(crate) fn as_bytes(&self) -> &[u8] {
             self.name.as_bytes()
         }
+
+        pub(crate) fn as_str(&self) -> &str {
+            self.name.as_str()
+        }
     }
 }
 
@@ -52,6 +56,13 @@ impl SymbolName {
         match self {
             SymbolName::Interned(x) => x.as_bytes(),
             SymbolName::Uninterned(x) => x.get().as_bytes(),
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        match self {
+            SymbolName::Interned(x) => x,
+            SymbolName::Uninterned(x) => x.get(),
         }
     }
 }

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -747,82 +747,105 @@ pub(crate) fn string_bytes(string: &str) -> i64 {
 }
 
 #[defun]
-pub(crate) fn string_lessp(string1: &str, string2: &str) -> bool {
-    for (c1, c2) in string1.chars().zip(string2.chars()) {
+pub(crate) fn string_lessp<'ob>(string1: Object<'ob>, string2: Object<'ob>) -> Result<bool> {
+    let string1 = match string1.untag() {
+        ObjectType::String(x) => x.chars().collect::<Vec<_>>(),
+        ObjectType::Symbol(x) => x.as_str().chars().collect::<Vec<_>>(),
+        _ => bail!(TypeError::new(Type::String, string1)),
+    };
+    let string2 = match string2.untag() {
+        ObjectType::String(x) => x.chars().collect::<Vec<_>>(),
+        ObjectType::Symbol(x) => x.as_str().chars().collect::<Vec<_>>(),
+        _ => bail!(TypeError::new(Type::String, string2)),
+    };
+    let string1_len = string1.len();
+    let string2_len = string2.len();
+    Ok(string_lessp_logic(
+        string1.into_iter(),
+        string1_len,
+        string2.into_iter(),
+        string2_len,
+    ))
+}
+
+#[inline]
+fn string_lessp_logic<I: Iterator<Item = char>>(
+    s1: I,
+    s1_len: usize,
+    s2: I,
+    s2_len: usize,
+) -> bool {
+    let len_comp = s1_len < s2_len;
+    for (c1, c2) in s1.zip(s2) {
         match std::cmp::Ord::cmp(&c1, &c2) {
             std::cmp::Ordering::Less => return true,
             std::cmp::Ordering::Greater => return false,
             _ => {}
         }
     }
-    string1.len() < string2.len()
+    len_comp
 }
 
 #[defun]
-pub(crate) fn string_version_lessp(string1: &str, string2: &str) -> bool {
-    let mut iter1 = string1.chars().peekable();
-    let mut char_len1 = 0;
-    let mut iter2 = string2.chars().peekable();
-    let mut char_len2 = 0;
-    let mut num1 = None;
-    let mut num2 = None;
-    //Peeking in order to try to match a pattern without progressing the iterator
-    while let (Some(c1), Some(c2)) = (iter1.peek(), iter2.peek()) {
-        // Copying the characters to avoid borrowing the iterator
-        let (c1, c2) = (*c1, *c2);
-        if c1.is_ascii_digit() {
-            num1 = Some(create_number(&mut iter1));
-        } else {
-            char_len1 += 1;
-            // Progressing the iterator because it wasn't a number
-            iter1.next();
-        }
-        if c2.is_ascii_digit() {
-            num2 = Some(create_number(&mut iter2));
-        } else {
-            char_len2 += 1;
-            // Progressing the iterator because it wasn't a number
-            iter2.next();
-        }
+pub(crate) fn string_version_lessp<'ob>(
+    string1: Object<'ob>,
+    string2: Object<'ob>,
+) -> Result<bool> {
+    let string1 = match string1.untag() {
+        ObjectType::String(x) => x.chars().collect::<Vec<_>>(),
+        ObjectType::Symbol(x) => x.as_str().chars().collect::<Vec<_>>(),
+        _ => bail!(TypeError::new(Type::String, string1)),
+    };
+    let string2 = match string2.untag() {
+        ObjectType::String(x) => x.chars().collect::<Vec<_>>(),
+        ObjectType::Symbol(x) => x.as_str().chars().collect::<Vec<_>>(),
+        _ => bail!(TypeError::new(Type::String, string2)),
+    };
+    let mut iter1 = string1.iter().peekable();
+    let mut iter2 = string2.iter().peekable();
+    let mut prefix1 = Vec::new();
+    let mut prefix2 = Vec::new();
 
-        if c1 != c2 {
-            if let (Some(n1), Some(n2)) = (num1, num2) {
-                if n1 != n2 {
-                    return n1 < n2;
-                } else {
-                    return c1 < c2;
-                }
-            } else {
-                return c1 < c2;
-            }
-        }
+    while let Some(c) = iter1.next_if(|c| !c.is_ascii_digit()) {
+        prefix1.push(*c);
+    }
+    let num1 = create_number(&mut iter1);
+
+    while let Some(c) = iter2.next_if(|c| !c.is_ascii_digit()) {
+        prefix2.push(*c);
+    }
+    let num2 = create_number(&mut iter2);
+
+    if prefix1 != prefix2 {
+        let prefix1_len = prefix1.len();
+        let prefix2_len = prefix2.len();
+        return Ok(string_lessp_logic(
+            prefix1.into_iter(),
+            prefix1_len,
+            prefix2.into_iter(),
+            prefix2_len,
+        ));
     }
 
-    println!("{:?} {:?}", num1, num2);
-
-    if let (Some(n1), Some(n2)) = (num1, num2) {
-        if n1 != n2 {
-            return n1 < n2;
-        }
+    if num1 != num2 {
+        return Ok(num1 < num2);
     }
 
-    // These loops are for getting the full count if one of the iterators is empty
-    for c in iter1 {
-        if !c.is_ascii_digit() {
-            char_len1 += 1;
-        }
-    }
-    for c in iter2 {
-        if !c.is_ascii_digit() {
-            char_len2 += 1;
-        }
-    }
+    let string1_len = string1.len();
+    let string2_len = string2.len();
 
-    char_len1 < char_len2
+    Ok(string_lessp_logic(
+        string1.into_iter(),
+        string1_len,
+        string2.into_iter(),
+        string2_len,
+    ))
 }
 /// Helper function to create a number from a string iterator
 #[inline]
-fn create_number<I: Iterator<Item = char>>(iter: &mut std::iter::Peekable<I>) -> usize {
+fn create_number<'ob, I: Iterator<Item = &'ob char>>(
+    iter: &'ob mut std::iter::Peekable<I>,
+) -> usize {
     let mut num = 0;
 
     while let Some(digit) = iter.next_if(|c| c.is_ascii_digit()) {
@@ -1100,6 +1123,7 @@ mod test {
 
     #[test]
     fn test_string_lessp() {
+        // String Tests
         // Test Equality
         assert_lisp("(string-lessp \"less\" \"less\")", "nil");
         // Test Length
@@ -1107,10 +1131,24 @@ mod test {
         assert_lisp("(string-lessp \"less\" \"les\")", "nil");
         // Check for less than
         assert_lisp("(string-lessp \"abc\" \"bcd\")", "t");
+
+        // Symbol Tests
+        // Test Equality
+        assert_lisp("(string-lessp 'less 'less)", "nil");
+        // Test Length
+        assert_lisp("(string-lessp 'les 'less)", "t");
+        assert_lisp("(string-lessp 'less 'les)", "nil");
+        // Check for less than
+        assert_lisp("(string-lessp 'abc 'bcd)", "t");
+
+        // Mixed Tests
+        assert_lisp("(string-lessp 'less \"less\")", "nil");
+        assert_lisp("(string-lessp 'les \"less\")", "t");
     }
 
     #[test]
     fn test_string_version_lessp() {
+        // String Tests
         // Test Equality
         assert_lisp("(string-version-lessp \"less\" \"less\")", "nil");
         // Test Length
@@ -1138,6 +1176,36 @@ mod test {
         // Test that that the first number is compared immediately at a char comparison
         assert_lisp("(string-version-lessp \"10a100\" \"0100a\")", "t");
         assert_lisp("(string-version-lessp \"a100\" \"0100a\")", "nil");
+
+        // Symbol Tests
+        // Test Equality
+        assert_lisp("(string-version-lessp 'less 'less)", "nil");
+        // Test Length
+        assert_lisp("(string-version-lessp 'les 'less)", "t");
+        assert_lisp("(string-version-lessp 'less 'les)", "nil");
+        // Check for less than
+        assert_lisp("(string-version-lessp 'abc 'bcd)", "t");
+        // Test Equality with number
+        assert_lisp("(string-version-lessp 'less1 'less1)", "nil");
+        assert_lisp("(string-version-lessp '100a '100b)", "t");
+        // Test Differing numeric position does matter
+        assert_lisp("(string-version-lessp '1less 'less1)", "t");
+        // Test Greater than numericaly
+        assert_lisp("(string-version-lessp 'less12 'less1)", "nil");
+        // Test Less than numericaly
+        assert_lisp("(string-version-lessp 'less1 'less12)", "t");
+        // Test that later numbers override previous ones
+        assert_lisp("(string-version-lessp '133less1 'less12)", "t");
+        // Test Numbers take higher precedence over characters
+        assert_lisp("(string-version-lessp '101a '100b)", "nil");
+        // Test Numbers that leading zeros are ignored
+        // Test that that the first number is compared immediately at a char comparison
+        assert_lisp("(string-version-lessp '10a100 '0100a)", "t");
+        assert_lisp("(string-version-lessp 'a100 '0100a)", "nil");
+
+        // Mixed Tests
+        assert_lisp("(string-version-lessp 'less \"less\")", "nil");
+        assert_lisp("(string-version-lessp 'less1 \"less10\")", "t");
     }
 
     #[test]

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -784,6 +784,31 @@ fn string_lessp_logic<I: Iterator<Item = char>>(
     len_comp
 }
 
+struct Version(Vec<usize>);
+
+impl std::cmp::PartialEq for Version {
+    fn eq(&self, other: &Self) -> bool {
+        for (a, b) in self.0.iter().zip(other.0.iter()) {
+            if a != b {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl std::cmp::PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        for (a, b) in self.0.iter().zip(other.0.iter()) {
+            match a.cmp(b) {
+                std::cmp::Ordering::Equal => continue,
+                x => return Some(x),
+            }
+        }
+        None
+    }
+}
+
 #[defun]
 pub(crate) fn string_version_lessp<'ob>(
     string1: Object<'ob>,
@@ -807,12 +832,12 @@ pub(crate) fn string_version_lessp<'ob>(
     while let Some(c) = iter1.next_if(|c| !c.is_ascii_digit()) {
         prefix1.push(c);
     }
-    let num1 = create_number(&mut iter1);
+    let ver1 = create_version(string1.chars().peekable());
 
     while let Some(c) = iter2.next_if(|c| !c.is_ascii_digit()) {
         prefix2.push(c);
     }
-    let num2 = create_number(&mut iter2);
+    let ver2 = create_version(string2.chars().peekable());
 
     if prefix1 != prefix2 {
         let prefix1_len = prefix1.len();
@@ -825,8 +850,8 @@ pub(crate) fn string_version_lessp<'ob>(
         ));
     }
 
-    if num1 != num2 {
-        return Ok(num1 < num2);
+    if ver1 != ver2 {
+        return Ok(ver1 < ver2);
     }
 
     let string1_len = string1.chars().count();
@@ -834,16 +859,25 @@ pub(crate) fn string_version_lessp<'ob>(
 
     Ok(string_lessp_logic(string1.chars(), string1_len, string2.chars(), string2_len))
 }
-/// Helper function to create a number from a string iterator
+/// Helper function to create a version from a string iterator
 #[inline]
-fn create_number<I: Iterator<Item = char>>(iter: &mut std::iter::Peekable<I>) -> usize {
-    let mut num = 0;
+fn create_version<I: Iterator<Item = char>>(mut iter: std::iter::Peekable<I>) -> Version {
+    let mut buf = Vec::new();
+    loop {
+        let mut num = 0;
 
-    while let Some(digit) = iter.next_if(|c| c.is_ascii_digit()) {
-        num = num * 10 + digit.to_digit(10).unwrap() as usize;
+        while iter.next_if(|c| !c.is_ascii_digit()).is_some() {}
+
+        while let Some(digit) = iter.next_if(|c| c.is_ascii_digit()) {
+            num = num * 10 + digit.to_digit(10).unwrap() as usize;
+        }
+        buf.push(num);
+
+        if iter.peek().is_none() {
+            break;
+        }
     }
-
-    num
+    Version(buf)
 }
 
 ///////////////
@@ -1168,6 +1202,7 @@ mod test {
         assert_lisp("(string-version-lessp \"10a100\" \"0100a\")", "t");
         assert_lisp("(string-version-lessp \"a100\" \"0100a\")", "nil");
         assert_lisp("(string-version-lessp \"01\" \"1\")", "nil");
+        assert_lisp("(string-version-lessp \"a1a10aa\" \"a1a0100\")", "t");
 
         // Symbol Tests
         // Test Equality

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -786,9 +786,19 @@ pub(crate) fn string_version_lessp(string1: &str, string2: &str) -> bool {
         }
 
         if c1 != c2 {
-            return c1 < c2;
+            if let (Some(n1), Some(n2)) = (num1, num2) {
+                if n1 != n2 {
+                    return n1 < n2;
+                } else {
+                    return c1 < c2;
+                }
+            } else {
+                return c1 < c2;
+            }
         }
     }
+
+    println!("{:?} {:?}", num1, num2);
 
     if let (Some(n1), Some(n2)) = (num1, num2) {
         if n1 != n2 {
@@ -1121,6 +1131,13 @@ mod test {
         assert_lisp("(string-version-lessp \"133less1\" \"less12\")", "t");
         // Test that digits don't disappear
         assert_lisp("(string-version-lessp \"112a\" \"512a\")", "t");
+        // Test Numbers take higher precedence over characters
+        assert_lisp("(string-version-lessp \"101a\" \"100b\")", "nil");
+        // Test Numbers that leading zeros are ignored
+        assert_lisp("(string-version-lessp \"10\" \"0100\")", "t");
+        // Test that that the first number is compared immediately at a char comparison
+        assert_lisp("(string-version-lessp \"10a100\" \"0100a\")", "t");
+        assert_lisp("(string-version-lessp \"a100\" \"0100a\")", "nil");
     }
 
     #[test]


### PR DESCRIPTION
Fix for #78. I rewrote `string-version-lessp` after looking at the source code for emacs and it should match the proper implementation. I did the same for `string-lessp` after learning that it also takes in symbols.

I had to implement a few helper functions in `src/core/object/symbol.rs` to allow for the comparing of symbols.

I also added tests that test symbols.