### PR TITLE
Add reader support for integer literals with numerical radix

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -453,7 +453,7 @@ impl<'a, 'ob> Reader<'a, 'ob> {
 
     /// Read number with specificed radix
     fn read_radix(&mut self, pos: usize, radix: u8) -> Result<Object<'ob>> {
-        if radix < 2 || radix > 36 {
+        if !(2..=36).contains(&radix) {
             return Err(Error::ParseInt(radix, pos));
         }
 


### PR DESCRIPTION
Emacs supports custom radix in range `[2, 36]` in integer literals using syntax `#<radix>r<integer>` where `radix` can be either `b`, `o`, `x` that we handled already or an integer.