### PR TITLE
feat(casefiddle): handle unicode in upcase

### DIFF
--- a/src/casefiddle.rs
+++ b/src/casefiddle.rs
@@ -8,6 +8,42 @@ fn capitalize(s: &str) -> String {
 
 #[defun]
 fn upcase(s: &str) -> String {
-    // TODO: use unicode
-    s.to_uppercase()
+    s.chars()
+        .flat_map(|c| c.to_uppercase())
+        .collect::<String>()
+        // re-escape string
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_upcase() {
+        // Basic escape characters
+        assert_eq!("\n", upcase("\n"));
+        assert_eq!("\t", upcase("\t"));
+        assert_eq!("\r", upcase("\r"));
+        assert_eq!(r#"\""#, upcase("\""));
+        assert_eq!(r#"\\"#, upcase("\\"));
+
+        // Control characters
+        assert_eq!("\u{0}", upcase("\u{0}"));
+        assert_eq!("\u{1B}", upcase("\u{1B}"));
+        assert_eq!("\u{7F}", upcase("\u{7F}"));
+
+        // Already escaped
+        assert_eq!(r#"\\N"#, upcase("\\n"));
+
+        // Non-ASCII characters
+        assert_eq!("ΑΒΓ", upcase("αβγ"));
+        assert_eq!("ÅÄÖ", upcase("åäö"));
+
+        // Mixed content
+        assert_eq!("HELLO\nWORLD", upcase("hello\nworld"));
+        assert_eq!("FOO\tBAR", upcase("foo\tbar"));
+        assert_eq!(r#"PATH\\TO\\FILE\"NAME\""#, upcase("path\\to\\file\"name\""));
+    }
 }


### PR DESCRIPTION
Hi! I saw your talk on EmacsConf 2024 and thought it was really interesting! Wanted to give a go at contributing and found something easy to begin with.

The solution is pretty straight-forward. I had to re-escape the string as that is how Emacs wants it.

```rust
#[defun]
fn upcase(s: &str) -> String {
    s.chars()
        .flat_map(|c| c.to_uppercase())
        .collect::<String>()
        .replace('\\', "\\\\")
        .replace('"', "\\\"")
}
```

However, it seems that Emacs doesn't yet know how to upcase the Garay alphabet. I found this out by running elprop. It might be due to the Unicode block being a recent addition. I'm quoting from Wikipedia:

> The Garay alphabet was added to the Unicode Standard in September, 2024 with the release of version 16.0.

Hence, the final solution involves a match on that particular Unicode block.
