### PR TITLE
feat(fns): implement clear_string

### DIFF
--- a/src/core/object/string.rs
+++ b/src/core/object/string.rs
@@ -100,6 +100,13 @@ impl LispString {
     pub(crate) fn len(&self) -> usize {
         self.chars().count()
     }
+
+    pub(crate) fn clear(&self) {
+        let inner_mut_str = unsafe { &mut *self.0 .0.get() };
+        for byte in unsafe { inner_mut_str.as_bytes_mut().iter_mut() } {
+            *byte = b'\0';
+        }
+    }
 }
 
 impl<'new> CloneIn<'new, &'new Self> for LispString {

--- a/src/fns.rs
+++ b/src/fns.rs
@@ -794,6 +794,12 @@ pub(crate) fn string_version_lessp<'ob>(
     Ok(filevercmp(string1.0.as_bytes(), string2.0.as_bytes()) == std::cmp::Ordering::Less)
 }
 
+#[defun]
+pub(crate) fn clear_string(string: &LispString) -> Result<Object> {
+    string.clear();
+    Ok(NIL)
+}
+
 ///////////////
 // HashTable //
 ///////////////
@@ -1234,5 +1240,14 @@ mod test {
     #[test]
     fn test_copy_alist() {
         assert_lisp("(copy-alist '((1 . 2) (3 . 4) (5 . 6)))", "((1 . 2) (3 . 4) (5 . 6))");
+    }
+
+    #[test]
+    fn test_clear_string() {
+        assert_lisp(
+            "(let ((str \"test string\")) (clear-string str) str)",
+            "\"\0\0\0\0\0\0\0\0\0\0\0\"",
+        );
+        assert_lisp("(let ((str \"\")) (clear-string str) str)", "\"\"");
     }
 }


### PR DESCRIPTION
This implements `clear_string` function. ~I was a little unsure how to do it so I ended up by exposing a new method on `LispString` to get a mutable reference to `&str`~.  UPDATE: implemented as a method `clear` on `LispString` instead.

```rust
    pub(crate) fn inner_mut(&self) -> &mut str {
        let ptr = self.0 .0.get();
        unsafe { &mut *ptr }
    }
```

From there on it was straight forward to just fill that `&mut str` with the null byte.