### PR TITLE
Don't parse non-*.rs files in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -73,6 +73,9 @@ fn main() {
         let entry = entry.unwrap();
         let path = entry.path();
         if path.is_file() {
+            if path.extension().and_then(OsStr::to_str) != Some("rs") {
+                continue;
+            }
             let contents = fs::read_to_string(&path).unwrap();
             for (start, end) in contents.match_indices("\n#[defun") {
                 let non_symbol = |c: char| !(c.is_alphanumeric() || c == '_');


### PR DESCRIPTION
build.rs previously parsed all files in src/**.  This meant for users of undo-tree, it would parse the very rust-like `*.rs.~undo-tree~` files it generated.  These would produce invalid results, causing compile failure and would poison the target directory.  By only parsing *.rs, we avoid this fate.