### PR TITLE
Implement set-char-table-parent

### DIFF
--- a/src/chartab.rs
+++ b/src/chartab.rs
@@ -1,7 +1,16 @@
-use crate::core::object::{CharTableInner, Object, Symbol};
+use crate::core::object::{CharTable, CharTableInner, Object, Symbol};
 use rune_macros::defun;
 
 #[defun]
 fn make_char_table<'ob>(_purpose: Symbol<'ob>, init: Option<Object<'ob>>) -> CharTableInner<'ob> {
     CharTableInner::new(init)
+}
+
+#[defun]
+fn set_char_table_parent<'ob>(
+    table: &'ob CharTable,
+    parent: Option<&'ob CharTable>,
+) -> Option<&'ob CharTable> {
+    table.set_parent(parent);
+    parent
 }

--- a/src/core/object/convert.rs
+++ b/src/core/object/convert.rs
@@ -6,7 +6,7 @@ use crate::data::LispError;
 
 use super::{
     super::error::{Type, TypeError},
-    ByteString, LispHashTable, LispString, LispVec, OptionalFlag, NIL, TRUE,
+    ByteString, CharTable, LispHashTable, LispString, LispVec, OptionalFlag, NIL, TRUE,
 };
 use super::{Gc, LispFloat, Object, ObjectType, Symbol};
 use anyhow::Context;
@@ -129,6 +129,7 @@ define_unbox!(String, &'ob LispString);
 define_unbox!(ByteString, String, &'ob ByteString);
 define_unbox!(Vec, &'ob LispVec);
 define_unbox!(Symbol, Symbol<'ob>);
+define_unbox!(CharTable, &'ob CharTable);
 
 impl<'ob, T> From<Option<T>> for Object<'ob>
 where


### PR DESCRIPTION
In this PR we implement `set-char-table-parent` in Rune. The Emacs document for it says 

```
set-char-table-parent is a primitive-function in ‘C source code’.

(set-char-table-parent CHAR-TABLE PARENT)

Set the parent char-table of CHAR-TABLE to PARENT.
Return PARENT.  PARENT must be either nil or another char-table.
```