### PR TITLE
Set edition in rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2024"
 max_width = 100
 single_line_let_else_max_width = 90
 single_line_if_else_max_width = 80


### PR DESCRIPTION
When rustfmt is called via `cargo fmt` --edition parameter is automatically set, but when it's called standalone (for example via Emacs' apheleia) `rustfmt` uses a default style edition of 2015. According to `rustfmt` documentation the edition should be set in `rustfmt.toml` as well as in Cargo.toml:

https://github.com/rust-lang/rustfmt?tab=readme-ov-file#rusts-editions

@CeleritasCelery, this actually caught me in the latest PR. I was sure the code is formatted by apheleia, but it turns out my rustfmt used wrong edition. What do you think about setting it in `rustfmt.toml`?