### PR TITLE
Introduce ability to run Windows tests via Wine

### DIFF
--- a/README.org
+++ b/README.org
@@ -92,6 +92,22 @@ Rune includes the `assert_elprop!` macro, which enables property testing against
        }
      #+end_src
 
+** How to run Windows tests on Linux with Wine
+
+1. Define WINEPREFIX: ~export WINEPREFIX=$PWD/.wine~
+2. Add ~x86_64-pc-windows-gnu~ to rust toolchain: ~rustup target add x86_64-pc-windows-gnu~
+3. Setup the wineprefix: `./scripts/setup-wineprefix`. This script will install Emacs inside the prefix as well
+
+Now you can run the tests on Windows like that: ~cargo test --target x86_64-pc-windows-gnu~. In case you use Nix enviroment you should skip 1 and 2 points.
+
+Also, you can tell ~eglot~ to check the code marked with ~#[cfg(windows)]~. Just add the following to .dir-locals.el and restart ~eglot~:
+
+#+begin_src elisp
+((nil
+       . ((eglot-workspace-configuration
+           . (:rust-analyzer (:cargo (:target "x86_64-pc-windows-gnu")))))))
+#+end_src
+
 ** Blog posts
 - [[https://coredumped.dev/2021/10/21/building-an-emacs-lisp-vm-in-rust/][tagged pointers in Rust]] :: My initial approach to creating tagged pointers in Rust. It serves as in intro to this project.
 - [[https://coredumped.dev/2022/04/11/implementing-a-safe-garbage-collector-in-rust/][implementing a safe garbage collector]] :: An overview of the garbage collector used in this project and how Rust enables safe GC abstractions.

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,12 @@
           fenixPkgs.stable.rustfmt
           fenixPkgs.stable.clippy
           fenixPkgs.complete.miri
+          fenixPkgs.targets.x86_64-pc-windows-gnu.stable.cargo
+          fenixPkgs.targets.x86_64-pc-windows-gnu.stable.rustc
+          fenixPkgs.targets.x86_64-pc-windows-gnu.stable.rust-src
+          fenixPkgs.targets.x86_64-pc-windows-gnu.stable.rust-std
+          fenixPkgs.targets.x86_64-pc-windows-gnu.stable.rustfmt
+          fenixPkgs.targets.x86_64-pc-windows-gnu.stable.clippy
         ];
       in
       {

--- a/scripts/setup-wineprefix
+++ b/scripts/setup-wineprefix
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e -x
+
+EMACS_DOWNLOAD_URL="https://mirror.bahnhof.net/pub/gnu/emacs/windows/emacs-29/emacs-29.4.zip"
+WINE_C_DRIVE="${WINEPREFIX}/drive_c"
+
+if [ -z "$WINEPREFIX" ]; then
+    echo "Error: WINEPREFIX must be defined"
+    exit 1;
+fi
+rm -rf $WINEPREFIX
+
+wine reg add "HKEY_CURRENT_USER\Environment" /v Path /t REG_SZ /d "C:\emacs\bin" /f
+
+wget --show-progress -O "${WINE_C_DRIVE}/emacs.zip" "${EMACS_DOWNLOAD_URL}"
+unzip "${WINE_C_DRIVE}/emacs.zip" -d "${WINE_C_DRIVE}/emacs/"


### PR DESCRIPTION
Of course real testing should be done on Windows, but it is so painful to develop Rune inside QEMU or even on Windows bare metal. TRAMP doesn't work with Powershell or bash.exe from MingW32, so you have to physically install Emacs on Windows inside QEMU and develop Rune this way. It makes switching painful and very unproductive.

The provided way to run Windows tests via Wine is not ideal either, but it works pretty well! Especially, when combined with changing the target for rust-analyzer and hence eglot.

@CeleritasCelery what do you think about adding this to the repo? This was my setup during assert_elprop! developing. I think Wine works better than anything else.